### PR TITLE
fix: Remove unused code

### DIFF
--- a/src/bitcoin/rust/mod.rs
+++ b/src/bitcoin/rust/mod.rs
@@ -90,17 +90,6 @@ impl LocalWallet {
         Network::Bitcoin // Default to mainnet
     }
 
-    fn sign_transaction(&self, _psbt: &mut bitcoin::psbt::Psbt) -> Result<(), BitcoinError> {
-        // Implementation for signing PSBT
-        // This is a simplified implementation
-        Ok(())
-    }
-
-    fn find_key_for_output(&self, _output: &bitcoin::TxOut) -> Option<String> {
-        // Implementation to find the key for a given output
-        // This is a simplified implementation
-        None
-    }
 }
 
 impl RustBitcoinImplementation {
@@ -150,28 +139,6 @@ impl RustBitcoinImplementation {
             .map_err(|e| BitcoinError::Other(format!("Failed to create RPC client: {}", e)))?;
         self.rpc_client = Some(rpc_client);
         Ok(self)
-    }
-
-    /// Get UTXOs for an address
-    async fn get_utxos(&self, _address: &str) -> Result<Vec<bitcoin::OutPoint>, BitcoinError> {
-        if let Some(_client) = &self.rpc_client {
-            // Implementation using RPC client
-            Ok(vec![])
-        } else {
-            // Fallback implementation
-            Ok(vec![])
-        }
-    }
-
-    /// Estimate fee rate for target blocks
-    async fn estimate_fee_rate(&self, _target_blocks: u32) -> Result<FeeRate, BitcoinError> {
-        if let Some(_client) = &self.rpc_client {
-            // Implementation using RPC client
-            Ok(FeeRate::from_sat_per_vb(10).unwrap())
-        } else {
-            // Fallback implementation
-            Ok(FeeRate::from_sat_per_vb(10).unwrap())
-        }
     }
 }
 

--- a/src/security/hsm/audit.rs
+++ b/src/security/hsm/audit.rs
@@ -919,14 +919,12 @@ impl AuditStorage for FileAuditStorage {
 /// Database storage for audit events
 #[derive(Debug)]
 pub struct DbAuditStorage {
-    connection_string: String,
     memory_storage: MemoryAuditStorage, // Fallback storage
 }
 
 impl DbAuditStorage {
-    pub fn new(connection_string: String) -> Self {
+    pub fn new(_connection_string: String) -> Self {
         Self {
-            connection_string,
             memory_storage: MemoryAuditStorage::new(),
         }
     }

--- a/src/security/hsm/mod.rs
+++ b/src/security/hsm/mod.rs
@@ -110,12 +110,10 @@ impl Default for HsmHealthStatus {
 pub struct HsmManager {
     config: HsmConfig,
     provider: Box<dyn HsmProvider>,
-    stats: HsmStats,
     enabled: bool,
     audit_logger: Arc<AuditLogger>,
     status: Arc<RwLock<HsmStatus>>,
     health_status: Arc<RwLock<HsmHealthStatus>>,
-    operation_tracker: Arc<Mutex<HashMap<String, (DateTime<Utc>, String)>>>,
 }
 
 impl HsmManager {
@@ -125,7 +123,6 @@ impl HsmManager {
             config.provider_type
         );
 
-        let stats = HsmStats::default();
         let audit_logger = Arc::new(AuditLogger::new(&config.audit).await?);
 
         let provider: Box<dyn HsmProvider> = match config.provider_type {
@@ -173,10 +170,8 @@ impl HsmManager {
         Ok(Self {
             config,
             provider,
-            stats,
             enabled: false,
             audit_logger,
-            operation_tracker: Arc::new(Mutex::new(HashMap::new())),
             status: Arc::new(RwLock::new(HsmStatus::Initializing)),
             health_status: Arc::new(RwLock::new(HsmHealthStatus::default())),
         })
@@ -771,13 +766,11 @@ pub struct AtomicSwap {
     redeem_script: ScriptBuf,
 }
 
-pub struct NetworkManager {
-    connected: bool,
-}
+pub struct NetworkManager;
 
 impl NetworkManager {
     pub fn new() -> Self {
-        Self { connected: false }
+        Self {}
     }
 
     pub async fn get_merkle_proof(&self, _txid: &Txid) -> Result<MerkleProof, Box<dyn Error>> {
@@ -920,7 +913,6 @@ impl MobileSDK {
 
 pub struct HsmBridge {
     provider: Box<dyn HsmProvider>,
-    connected: bool,
 }
 
 impl HsmBridge {

--- a/src/security/hsm/provider.rs
+++ b/src/security/hsm/provider.rs
@@ -516,16 +516,14 @@ pub async fn create_hsm_provider(config: &HsmConfig) -> Result<Arc<dyn HsmProvid
 /// This provider is used for development and testing purposes only.
 #[derive(Debug)]
 pub struct SoftHsmProvider {
-    config: SoftHsmConfig,
     keys: Mutex<HashMap<String, KeyInfo>>,
     key_data: Mutex<HashMap<String, Vec<u8>>>, // For private key data (in a real HSM, this would never be exposed)
 }
 
 impl SoftHsmProvider {
     /// Create a new SoftHSM provider
-    pub fn new(config: &SoftHsmConfig) -> Result<Self, HsmError> {
+    pub fn new(_config: &SoftHsmConfig) -> Result<Self, HsmError> {
         Ok(Self {
-            config: config.clone(),
             keys: Mutex::new(HashMap::new()),
             key_data: Mutex::new(HashMap::new()),
         })
@@ -834,16 +832,12 @@ impl HsmProvider for SoftHsmProvider {
 
 /// CloudHSM provider
 #[derive(Debug)]
-pub struct CloudHsmProvider {
-    config: CloudHsmConfig,
-}
+pub struct CloudHsmProvider;
 
 impl CloudHsmProvider {
     /// Create a new CloudHSM provider
-    pub fn new(config: &CloudHsmConfig) -> Result<Self, HsmError> {
-        Ok(Self {
-            config: config.clone(),
-        })
+    pub fn new(_config: &CloudHsmConfig) -> Result<Self, HsmError> {
+        Ok(Self)
     }
 }
 
@@ -933,16 +927,12 @@ impl HsmProvider for CloudHsmProvider {
 
 /// TPM provider
 #[derive(Debug)]
-pub struct TpmProvider {
-    config: TpmConfig,
-}
+pub struct TpmProvider;
 
 impl TpmProvider {
     /// Create a new TPM provider
-    pub fn new(config: &TpmConfig) -> Result<Self, HsmError> {
-        Ok(Self {
-            config: config.clone(),
-        })
+    pub fn new(_config: &TpmConfig) -> Result<Self, HsmError> {
+        Ok(Self)
     }
 }
 
@@ -1032,16 +1022,12 @@ impl HsmProvider for TpmProvider {
 
 /// PKCS#11 provider
 #[derive(Debug)]
-pub struct Pkcs11Provider {
-    config: Pkcs11Config,
-}
+pub struct Pkcs11Provider;
 
 impl Pkcs11Provider {
     /// Create a new PKCS#11 provider
-    pub fn new(config: &Pkcs11Config) -> Result<Self, HsmError> {
-        Ok(Self {
-            config: config.clone(),
-        })
+    pub fn new(_config: &Pkcs11Config) -> Result<Self, HsmError> {
+        Ok(Self)
     }
 }
 

--- a/src/security/hsm/providers/bitcoin.rs
+++ b/src/security/hsm/providers/bitcoin.rs
@@ -30,9 +30,6 @@ use crate::security::hsm::provider::{
 /// Bitcoin HSM Provider
 #[derive(Debug)]
 pub struct BitcoinHsmProvider {
-    /// Configuration
-    config: BitcoinConfig,
-
     /// Network
     network: Network,
 
@@ -79,7 +76,6 @@ impl BitcoinHsmProvider {
         let secp = Secp256k1::new();
 
         let provider = Self {
-            config: config.clone(),
             network,
             secp,
             keys: Mutex::new(HashMap::new()),

--- a/src/security/hsm/providers/hardware.rs
+++ b/src/security/hsm/providers/hardware.rs
@@ -30,12 +30,7 @@ enum ConnectionState {
 
 /// Device information
 #[derive(Debug, Clone)]
-struct DeviceInfo {
-    model: String,
-    serial: String,
-    firmware_version: String,
-    max_keys: usize,
-}
+struct DeviceInfo;
 
 /// Hardware HSM provider for physical security devices
 #[derive(Debug)]
@@ -79,32 +74,7 @@ impl HardwareHsmProvider {
         }
 
         // Simulate connection based on device type
-        let device_info = match self.config.device_type {
-            HardwareDeviceType::YubiHsm => DeviceInfo {
-                model: "YubiHSM 2".to_string(),
-                serial: "1234567890".to_string(),
-                firmware_version: "2.3.0".to_string(),
-                max_keys: 256,
-            },
-            HardwareDeviceType::Ledger => DeviceInfo {
-                model: "Ledger Nano S".to_string(),
-                serial: "LDG987654321".to_string(),
-                firmware_version: "2.1.0".to_string(),
-                max_keys: 100,
-            },
-            HardwareDeviceType::TrezorModel => DeviceInfo {
-                model: "Trezor Model T".to_string(),
-                serial: "TRZ123456789".to_string(),
-                firmware_version: "1.10.4".to_string(),
-                max_keys: 100,
-            },
-            HardwareDeviceType::Custom => DeviceInfo {
-                model: "Custom HSM".to_string(),
-                serial: "CST000000001".to_string(),
-                firmware_version: "1.0.0".to_string(),
-                max_keys: 500,
-            },
-        };
+        let device_info = DeviceInfo;
 
         // Update device info and state
         *state = ConnectionState::Connected;
@@ -236,7 +206,7 @@ impl HardwareHsmProvider {
 
         // Get key info
         let keys = self.keys.lock().await;
-        let key_info = keys
+        let _key_info = keys
             .get(key_id)
             .ok_or_else(|| HsmError::KeyNotFound(key_id.to_string()))?;
 

--- a/src/security/hsm/providers/ledger.rs
+++ b/src/security/hsm/providers/ledger.rs
@@ -39,8 +39,6 @@ pub struct LedgerConfig {
 /// Ledger HSM Provider for hardware wallet integration
 #[derive(Debug)]
 pub struct LedgerHsmProvider {
-    /// Provider configuration
-    config: LedgerConfig,
     /// Keys (actually BIP32 paths) known to this provider
     keys: tokio::sync::Mutex<HashMap<String, KeyInfo>>,
     /// Audit logger
@@ -49,18 +47,13 @@ pub struct LedgerHsmProvider {
 
 impl LedgerHsmProvider {
     /// Create a new Ledger HSM provider
-    pub fn new(config: &LedgerConfig, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
+    pub fn new(_config: &LedgerConfig, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
         Ok(Self {
-            config: config.clone(),
             keys: tokio::sync::Mutex::new(HashMap::new()),
             audit_logger,
         })
     }
 
-    /// Generate a unique key ID
-    fn generate_key_id(&self) -> String {
-        Uuid::new_v4().to_string()
-    }
 }
 
 #[async_trait]
@@ -149,7 +142,7 @@ impl HsmProvider for LedgerHsmProvider {
         request: provider::HsmRequest,
     ) -> Result<provider::HsmResponse, HsmError> {
         // Just return an unsupported operation error for now
-        let request_id = request.id.clone();
+        let _request_id = request.id.clone();
         Err(HsmError::UnsupportedOperation(format!(
             "Operation {:?} not supported in the Ledger provider stub implementation",
             request.operation

--- a/src/security/hsm/providers/pkcs11.rs
+++ b/src/security/hsm/providers/pkcs11.rs
@@ -27,10 +27,6 @@ use crate::security::hsm::provider::{
 /// Currently implemented as a stub with placeholder functionality.
 #[derive(Debug)]
 pub struct Pkcs11HsmProvider {
-    /// Provider configuration
-    config: Pkcs11Config,
-    /// Keys stored in the HSM
-    keys: Mutex<HashMap<String, KeyInfo>>,
     /// Audit logger for security events
     audit_logger: Arc<AuditLogger>,
 }
@@ -40,23 +36,14 @@ impl Pkcs11HsmProvider {
     ///
     /// # Arguments
     ///
-    /// * `config` - The PKCS#11 configuration
+    /// * `_config` - The PKCS#11 configuration
     /// * `audit_logger` - Logger for security audit events
     ///
     /// # Returns
     ///
     /// A new PKCS#11 HSM provider or an error if initialization fails
-    pub fn new(config: &Pkcs11Config, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
-        Ok(Self {
-            config: config.clone(),
-            keys: Mutex::new(HashMap::new()),
-            audit_logger,
-        })
-    }
-
-    /// Generate a unique key ID
-    fn generate_key_id(&self) -> String {
-        Uuid::new_v4().to_string()
+    pub fn new(_config: &Pkcs11Config, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
+        Ok(Self { audit_logger })
     }
 
     /// Log a stub operation attempt


### PR DESCRIPTION
This commit addresses a number of warnings related to unused code.

- Unused variables have been prefixed with an underscore.
- Unused methods and functions have been removed.
- Unused struct fields have been removed.

These changes reduce the number of warnings and improve the overall code quality.
