### PR TITLE
Fix: Update workflow permissions and remove submodule reference

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  labels: write
 
 jobs:
   pr-checks:

--- a/COMMIT_INSTRUCTIONS.md
+++ b/COMMIT_INSTRUCTIONS.md
@@ -113,7 +113,6 @@ git commit -m "Restructure main application
 
 ### 8. CI/Debug
 ```bash
-git add anya-core-ci-debug/
 git commit -m "Add CI/Debug configuration
 
 - Add debugging configurations

--- a/commit-safely.sh
+++ b/commit-safely.sh
@@ -106,7 +106,6 @@ git commit -m "Restructure main application
 
 # Group 8: CI/Debug
 echo "Committing CI/Debug configuration..."
-git add anya-core-ci-debug/ || true
 git commit -m "Add CI/Debug configuration
 
 - Add debugging configurations


### PR DESCRIPTION
This pull request includes changes to improve automation permissions and remove unused commands related to CI/Debug configuration. The most important updates involve granting additional permissions in the GitHub Actions workflow and cleaning up unused commands in documentation and scripts.

### Automation Permissions:
* [`.github/workflows/pr-automation.yml`](diffhunk://#diff-ca8e3c833313d158daa59ebc91a85da71b3f8f9b5a641a1f4922cc983f23bd0eR13): Added `labels: write` permission to the GitHub Actions workflow to enable automation tasks that require label management.

### CI/Debug Cleanup:
* [`COMMIT_INSTRUCTIONS.md`](diffhunk://#diff-7b839b7a3e893982fce0dc0c9bd11e98be2e99f34a1ae3a8bc8421b92768c4edL116): Removed the unused `git add anya-core-ci-debug/` command from the CI/Debug section of the commit instructions.
* [`commit-safely.sh`](diffhunk://#diff-90ef097ff7f56a1237677cfaa9a58f1b266817a9f4641e16d3ffef9db3fb20f1L109): Removed the unused `git add anya-core-ci-debug/` command from the CI/Debug section of the script.