### PR TITLE
Fix compilation errors and warnings

### DIFF
--- a/src/security/hsm/mod.rs
+++ b/src/security/hsm/mod.rs
@@ -60,8 +60,7 @@ use bitcoin::taproot::TaprootBuilder;
 use bitcoin::{Network, Psbt, Script, Txid, XOnlyPublicKey};
 use chrono::{DateTime, Utc};
 use secp256k1::ecdsa::Signature;
-use std::collections::HashMap;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 
 use self::config::HsmConfig;

--- a/src/security/hsm/providers/hardware.rs
+++ b/src/security/hsm/providers/hardware.rs
@@ -206,7 +206,7 @@ impl HardwareHsmProvider {
 
         // Get key info
         let keys = self.keys.lock().await;
-        let _key_info = keys
+        let key_info = keys
             .get(key_id)
             .ok_or_else(|| HsmError::KeyNotFound(key_id.to_string()))?;
 

--- a/src/security/hsm/providers/ledger.rs
+++ b/src/security/hsm/providers/ledger.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 // External crates
 use async_trait::async_trait;
 use bitcoin::Network;
-use uuid::Uuid;
 
 // [AIR-3][AIS-3][BPC-3][RES-3] Import HSM module types following BDF v2.5 standards
 use crate::security::hsm::audit::AuditLogger;

--- a/src/security/hsm/providers/pkcs11.rs
+++ b/src/security/hsm/providers/pkcs11.rs
@@ -8,10 +8,7 @@
 //! functionality in future versions.
 
 use async_trait::async_trait;
-use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use uuid::Uuid;
 
 use crate::security::hsm::audit::AuditLogger;
 use crate::security::hsm::config::Pkcs11Config;

--- a/src/security/hsm/providers/software.rs
+++ b/src/security/hsm/providers/software.rs
@@ -40,9 +40,8 @@ use zeroize::Zeroize;
 // [AIR-3][AIS-3][BPC-3][RES-3] Import Bitcoin types for software HSM implementation
 // This follows official Bitcoin Improvement Proposals (BIPs) standards for secure HSM implementation
 use bitcoin::{
-    hashes::Hash as BitcoinHash,
-    secp256k1::{Message, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey},
-    Network, Psbt,
+    secp256k1::{Message, PublicKey, Secp256k1, SecretKey},
+    Network,
 };
 
 // [AIR-3][AIS-3][BPC-3][RES-3] Import secure random number generation
@@ -54,17 +53,13 @@ use crate::security::hsm::{
         EcCurve, HsmOperation, HsmProvider, HsmProviderStatus, HsmRequest, HsmResponse,
         KeyGenParams, KeyInfo, KeyPair, KeyType, KeyUsage, SigningAlgorithm,
     },
-    types::{
-        DecryptParams, DeleteKeyParams, EncryptParams, GetKeyParams, SignParams, VerifyParams,
-    },
+    types::{DeleteKeyParams, GetKeyParams, SignParams, VerifyParams},
 };
 
 // Import from parent modules
 use crate::security::hsm::audit::AuditLogger;
 use crate::security::hsm::config::SoftHsmConfig;
 use crate::security::hsm::error::{AuditEventResult, AuditEventSeverity, AuditEventType};
-use base64::Engine;
-use bitcoin::key::Keypair;
 use chrono::{DateTime, Utc};
 use sha2::Digest;
 use sha2::{Sha256, Sha384};
@@ -831,22 +826,3 @@ impl HsmProvider for SoftwareHsmProvider {
     }
 }
 
-/// Parameters for rotating a key
-#[derive(Debug, serde::Deserialize)]
-struct RotateKeyParams {
-    key_id: String,
-}
-
-/// Parameters for Bitcoin transaction signing
-#[derive(Debug, serde::Deserialize)]
-struct BitcoinTxSignParams {
-    key_id: String,
-    psbt: String,
-}
-
-/// Response for signature in base64 format
-#[derive(Debug, serde::Serialize)]
-struct Base64SignatureResponse {
-    signature: String,
-    algorithm: SigningAlgorithm,
-}

--- a/src/security/hsm/providers/tpm.rs
+++ b/src/security/hsm/providers/tpm.rs
@@ -23,16 +23,14 @@ use std::fmt::Debug;
 /// TPM-based HSM provider implementation
 #[derive(Debug)]
 pub struct TpmHsmProvider {
-    config: TpmConfig,
     audit_logger: Arc<AuditLogger>,
     key_store: Mutex<HashMap<String, KeyInfo>>,
     key_data: Mutex<HashMap<String, Vec<u8>>>,
 }
 
 impl TpmHsmProvider {
-    pub fn new(config: &TpmConfig, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
+    pub fn new(_config: &TpmConfig, audit_logger: Arc<AuditLogger>) -> Result<Self, HsmError> {
         Ok(Self {
-            config: config.clone(),
             audit_logger,
             key_store: Mutex::new(HashMap::new()),
             key_data: Mutex::new(HashMap::new()),

--- a/src/security/hsm/security.rs
+++ b/src/security/hsm/security.rs
@@ -1,20 +1,7 @@
 // Security Manager Implementation for Anya Core HSM
 use std::collections::HashMap;
 use std::error::Error;
-use std::fmt;
 use std::sync::{Arc, Mutex, RwLock};
-
-/// Wrapper for Argon2 errors to implement std::error::Error
-#[derive(Debug)]
-struct Argon2ErrorWrapper(String);
-
-impl fmt::Display for Argon2ErrorWrapper {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Argon2 error: {}", self.0)
-    }
-}
-
-impl Error for Argon2ErrorWrapper {}
 
 use crate::security::hsm::HsmManager;
 use crate::AnyaResult;
@@ -23,8 +10,6 @@ use secp256k1::ecdsa::Signature;
 
 /// Security Manager for cryptographic operations
 pub struct SecurityManager {
-    /// HSM manager for hardware security operations
-    hsm: Arc<HsmManager>,
     /// User activation status - operations require explicit activation
     activation_status: RwLock<bool>,
     /// Key cache for performance optimization
@@ -33,9 +18,8 @@ pub struct SecurityManager {
 
 impl SecurityManager {
     /// Create a new security manager with HSM integration
-    pub fn new(hsm: Arc<HsmManager>) -> Self {
+    pub fn new(_hsm: Arc<HsmManager>) -> Self {
         Self {
-            hsm,
             activation_status: RwLock::new(false),
             key_cache: Mutex::new(HashMap::new()),
         }


### PR DESCRIPTION
This pull request includes several changes aimed at simplifying the codebase by removing unused imports, redundant structures, and unused fields, as well as improving overall maintainability. The changes primarily focus on the `security/hsm` module and its providers.

### Codebase Simplification:

#### Unused Imports Removal:
* Removed unused imports such as `HashMap`, `Mutex`, `Uuid`, and `Keypair` across multiple files, including `mod.rs`, `ledger.rs`, `pkcs11.rs`, and `software.rs`. This helps reduce clutter and improve readability. [[1]](diffhunk://#diff-9d0446e1cd87c0f9dfa76703faa8ebfa5c2d185e9f9110cbd959220ece9b791dL63-R63) [[2]](diffhunk://#diff-6340b64ff9356847853560ded687d4d43d92da6dfc3c9e20b39878c04c82a121L14) [[3]](diffhunk://#diff-66e6156baa949f09cc2bdeef60ead00029ffc7622bfaeaa530c3f7952a1bec96L11-L14) [[4]](diffhunk://#diff-83c8491e44bf2ad4b49b10759e4ea4a844449172c719e81c1a1c3c22a2c9a35eL43-R44)

#### Unused Structures and Fields:
* Removed unused structures like `RotateKeyParams`, `BitcoinTxSignParams`, and `Base64SignatureResponse` from `software.rs`.
* Removed the `config` field from `TpmHsmProvider` in `tpm.rs` and updated the constructor to no longer require it.
* Removed the `hsm` field from `SecurityManager` in `security.rs` and updated the `new` method accordingly.

### Code Maintenance:
* Removed the `Argon2ErrorWrapper` struct and its associated `Error` implementation from `security.rs`, as it was no longer in use.

These changes collectively improve the maintainability and clarity of the codebase by eliminating unused code and simplifying structures.