### PR TITLE
addressing all cargo clippy warnings.

### DIFF
--- a/src/bin/lightning_demo.rs
+++ b/src/bin/lightning_demo.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("     Funding txid: {:?}", tx.funding_txid);
                 println!("     Status: {:?}", tx.status);
                 if let Some(txid) = tx.closing_txid {
-                    println!("     Closing txid: {:?}", txid);
+                    println!("     Closing txid: {txid:?}");
                 }
             }
         }

--- a/src/bitcoin/lightning.rs
+++ b/src/bitcoin/lightning.rs
@@ -56,9 +56,11 @@ impl LightningPublicKey {
         bytes.copy_from_slice(&public_key.serialize());
         LightningPublicKey { bytes }
     }
+}
 
-    pub fn to_string(&self) -> String {
-        hex::encode(self.bytes)
+impl fmt::Display for LightningPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.bytes))
     }
 }
 
@@ -75,9 +77,11 @@ impl LightningTxid {
         bytes.copy_from_slice(slice);
         Ok(LightningTxid(bytes))
     }
+}
 
-    pub fn to_string(&self) -> String {
-        hex::encode(self.0)
+impl fmt::Display for LightningTxid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 

--- a/src/bitcoin/rust/mod.rs
+++ b/src/bitcoin/rust/mod.rs
@@ -58,7 +58,7 @@ impl LocalWallet {
             .secp
             .generate_keypair(&mut secp256k1::rand::thread_rng());
         let bitcoin_pubkey = bitcoin::PublicKey::new(public_key);
-        let key_id = format!("key_{}", bitcoin_pubkey.to_string());
+        let key_id = format!("key_{bitcoin_pubkey}");
         let network = self.network();
         let address = match address_type {
             AddressType::P2PKH => {
@@ -152,7 +152,7 @@ impl RustBitcoinImplementation {
         rpc_auth: bitcoincore_rpc::Auth,
     ) -> Result<Self, BitcoinError> {
         let rpc_client = bitcoincore_rpc::Client::new(&rpc_url, rpc_auth)
-            .map_err(|e| BitcoinError::Other(format!("Failed to create RPC client: {}", e)))?;
+            .map_err(|e| BitcoinError::Other(format!("Failed to create RPC client: {e}")))?;
         self.rpc_client = Some(rpc_client);
         Ok(self)
     }
@@ -202,7 +202,7 @@ impl BitcoinInterface for RustBitcoinImplementation {
 
     async fn generate_address(&self, address_type: AddressType) -> BitcoinResult<Address> {
         let mut wallet = LocalWallet::new();
-        let (_key_id, bitcoin_address) = wallet.generate_key(address_type.clone())?;
+        let (_key_id, bitcoin_address) = wallet.generate_key(address_type)?;
 
         Ok(bitcoin_address)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ impl From<serde_json::Error> for AnyaError {
 pub type AnyaResult<T> = Result<T, AnyaError>;
 
 /// Core configuration for the Anya system
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AnyaConfig {
     /// ML system configuration
     pub ml_config: ml::MLConfig,
@@ -409,20 +409,6 @@ pub struct AnyaConfig {
     pub bitcoin_config: crate::security::hsm_shim::HsmConfig,
     /// DAO configuration
     pub dao_config: dao::DAOConfig,
-}
-
-impl Default for AnyaConfig {
-    fn default() -> Self {
-        Self {
-            ml_config: ml::MLConfig::default(),
-            web5_config: web5::Web5Config::default(),
-            #[cfg(feature = "hsm")]
-            bitcoin_config: crate::security::hsm::config::HsmConfig::default(),
-            #[cfg(not(feature = "hsm"))]
-            bitcoin_config: crate::security::hsm_shim::HsmConfig::default(),
-            dao_config: dao::DAOConfig::default(),
-        }
-    }
 }
 
 /// Core Anya system

--- a/src/security/hsm_shim.rs
+++ b/src/security/hsm_shim.rs
@@ -28,9 +28,10 @@ pub struct HsmStubError {
 }
 
 /// [AIR-3][AIS-3][BPC-3][SEC-2] Security classification for HSM errors
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SecurityLevel {
     /// Informational security message
+    #[default]
     Info,
     /// Warning security message
     Warning,
@@ -220,11 +221,6 @@ pub trait HsmProvider: Send + Sync {
     }
 }
 
-impl Default for SecurityLevel {
-    fn default() -> Self {
-        SecurityLevel::Info
-    }
-}
 
 /// [AIR-3][AIS-3][BPC-3][RES-3][SEC-2] Enhanced Bitcoin HSM Provider
 /// This follows official Bitcoin Improvement Proposals (BIPs) standards
@@ -359,9 +355,10 @@ pub struct HsmConfig {
 impl HsmConfig {
     /// Create a new HSM config with the given provider type
     pub fn new(provider: &str) -> Self {
-        let mut config = Self::default();
-        config.provider_type = provider.to_string();
-        config
+        HsmConfig {
+            provider_type: provider.to_string(),
+            ..Default::default()
+        }
     }
 
     /// Add a configuration parameter

--- a/src/tools/source_of_truth_registry.rs
+++ b/src/tools/source_of_truth_registry.rs
@@ -193,7 +193,7 @@ impl SourceOfTruthRegistry {
         }
 
         // Load existing registry if it exists
-        if let Err(_) = registry.load_from_disk().await {
+        if registry.load_from_disk().await.is_err() {
             // If loading fails, initialize with empty registry
             registry.save_to_disk().await?;
         }
@@ -230,8 +230,7 @@ impl SourceOfTruthRegistry {
         let duplication_status = self.check_work_item_duplication(&title, &component).await?;
         if matches!(duplication_status, DuplicationCheckStatus::Failed(_)) {
             return Err(SourceOfTruthError::DuplicationDetected(format!(
-                "Work item title or component already exists: {}",
-                title
+                "Work item title or component already exists: {title}"
             )));
         }
 


### PR DESCRIPTION
This pull request includes multiple changes aimed at improving code readability, consistency, and maintainability across various modules. The changes primarily involve replacing manual string formatting with Rust's `{}` interpolation, refactoring to use `Default` trait derivations, and simplifying error handling expressions.

### Code readability and formatting improvements:
* Replaced manual `.to_string()` calls with Rust's `{}` interpolation for `bitcoin_pubkey` in `src/bitcoin/rust/mod.rs` and error messages in `src/bitcoin/rust/mod.rs` and `src/tools/source_of_truth_registry.rs`. [[1]](diffhunk://#diff-e62544fd72dc2b3ca375e7f950ae488aa3df62ef076bb5af4dca587d5faa967eL61-R61) [[2]](diffhunk://#diff-e62544fd72dc2b3ca375e7f950ae488aa3df62ef076bb5af4dca587d5faa967eL155-R155) [[3]](diffhunk://#diff-e76086cf7f05590c9d2b12b2a294603b0205792038aec16214d8b9383d591866L233-R233)

### Trait implementation refactoring:
* Replaced custom `to_string` methods with `fmt::Display` trait implementations for `LightningPublicKey` and `LightningTxid` in `src/bitcoin/lightning.rs`. [[1]](diffhunk://#diff-3aaccffe27c955da2f563fd1e59344f06161d7721d21e6c44daf21fa09a0c63eR59-R63) [[2]](diffhunk://#diff-3aaccffe27c955da2f563fd1e59344f06161d7721d21e6c44daf21fa09a0c63eR80-R84)

### Use of `Default` trait:
* Derived `Default` for `AnyaConfig` in `src/lib.rs` and removed the manual implementation. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L399-R399) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L414-L427)
* Derived `Default` for `SecurityLevel` in `src/security/hsm_shim.rs` and removed the manual implementation. [[1]](diffhunk://#diff-9f60fcafa7229750ca1f0f70066247cffc372a8b924c595d6d36b3d0c3600291L31-R34) [[2]](diffhunk://#diff-9f60fcafa7229750ca1f0f70066247cffc372a8b924c595d6d36b3d0c3600291L223-L227)
* Simplified the `HsmConfig::new` method in `src/security/hsm_shim.rs` by leveraging the `..Default::default()` syntax.

### Simplified error handling:
* Replaced `if let Err(_)` with `is_err()` for error checking in `src/tools/source_of_truth_registry.rs` to improve clarity.

These changes collectively enhance the maintainability and readability of the codebase while adhering to Rust best practices.