### PR TITLE
Fix: Correct CI configuration and submodule setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "anya-enterprise"]
+    path = anya-enterprise
+    url = git@github.com:botshelomokoka/anya-enterprise.git
+	branch = main
+    update = rebase
+[submodule "anya-core-ci-debug"]
+    path = anya-core-ci-debug
+    url = https://github.com/Anya-org/anya-core-ci-debug.git

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly"
-components = ["rust-src"]
+components = ["rust-src", "rustfmt"]
 # Using latest nightly to support edition2024 required by base64ct v1.8.0


### PR DESCRIPTION
This pull request introduces two main changes: the addition of new Git submodules and the inclusion of the `rustfmt` component in the Rust toolchain configuration.

### Submodule additions:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R8): Added two new submodules, `anya-enterprise` and `anya-core-ci-debug`, with their respective paths and URLs. The `anya-enterprise` submodule also specifies the `main` branch and uses `rebase` for updates.

### Rust toolchain update:
* [`rust-toolchain.toml`](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL3-R3): Added the `rustfmt` component to the Rust toolchain configuration, enabling code formatting capabilities alongside the existing `rust-src` component.