### PR TITLE
Fix: Add Default impl for ContractManager to resolve clippy warning

### DIFF
--- a/src/layer2/rgb/mod.rs
+++ b/src/layer2/rgb/mod.rs
@@ -155,6 +155,12 @@ pub struct ContractManager {
     _placeholder: (),
 }
 
+impl Default for ContractManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ContractManager {
     /// [AIR-3][AIS-3][BPC-3][RES-3] Generate a unique asset ID using Taproot-compatible hashing
     /// This follows official Bitcoin Improvement Proposals (BIPs) standards for asset ID generation


### PR DESCRIPTION
This pull request introduces a `Default` implementation for the `ContractManager` struct in the `src/layer2/rgb/mod.rs` file, allowing instances of `ContractManager` to be created using the `Default` trait.

Key change:

* Added a `Default` implementation for the `ContractManager` struct, delegating to the existing `new` method for instance creation.